### PR TITLE
Allow benchmark against any server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ docs/
 .env
 .jekyll-metadata
 _site
+options.json

--- a/README.md
+++ b/README.md
@@ -66,19 +66,43 @@ $ npm start
 ### Usage
 
 ```
-$ npm start -- run <args>  # runs many to many benchmark tests
-$ npm start -- test <server> <benchmark> <args>  # runs one to one benchmark test
-```
-
-You can pass in the file name of the [server][server] and [benchmark][benchmark] to test against.
-
-#### Arguments
-
-```
 -c, --connections The number of concurrent connections to use. default: 10.
 -p, --pipelining  The number of pipelined requests to use. default: 1.
 -d, --duration    The number of seconds to run the autocannnon. default: 10.
 -h, --help        output usage information
+```
+
+#### One to One Benchmark
+
+You can pass in the file name of the [server][server] and [benchmark][benchmark] to test against.
+
+```
+$ npm start -- test <server> <benchmark> <args>  # runs one to one benchmark test
+```
+
+Example: [servers/mongo][server] [benchmarks/get][benchmark]
+
+```
+# 100 connections, 1 thread, run for 20 seconds
+$ npm start -- test mongo get -c 100 -p 1 -d 20
+```
+
+#### All Benchmarks
+
+```
+$ npm start -- run <args> 
+```
+
+#### Connect to any server
+
+This tool uses [autocannon][autocannon] under the hood. You can pass options directly to run against any server.
+
+The is a sample json file [options.sample.json][options.sample.json].
+
+Learn more about options [here][autocannon-options].
+
+```
+$ npm start -- options <path to json> <args> 
 ```
 
 ### Environment Variables
@@ -107,6 +131,8 @@ You can generate detailed server logs by setting `VERBOSE=1`.
 
 You can track the progress of this project [here][project].
 
+[autocannon]: https://github.com/mcollina/autocannon
+[autocannon-options]: https://github.com/mcollina/autocannon#usage
 [benchmark]: https://github.com/parse-community/benchmark/tree/master/benchmarks
 [project]: https://github.com/parse-community/benchmark/projects
 [server]: https://github.com/parse-community/benchmark/tree/master/servers

--- a/options.sample.json
+++ b/options.sample.json
@@ -1,0 +1,19 @@
+{
+  "url": "http://localhost:1337",
+  "headers": {
+    "cache-control": false,
+    "content-type": "application/json",
+    "X-Parse-Application-Id": "",
+    "X-Parse-Master-Key": "",
+    "X-Parse-REST-API-Key": "",
+    "X-Parse-Javascript-Key": ""
+  },
+  "requests": [{
+    "path": "/classes/TestObject",
+    "method": "POST",
+    "body": "{\"testValue\":1}"
+  }],
+  "connections": 100,
+  "pipelining": 1,
+  "duration": 20
+}

--- a/src/autocannon.js
+++ b/src/autocannon.js
@@ -1,20 +1,7 @@
 'use strict';
-
 const autocannon = require('autocannon');
-const PARSE_CONFIG = require('./config');
 
-module.exports.run = (opts = {}, requests = []) => new Promise((resolve, reject) => {
-  opts.url = opts.serverURL || PARSE_CONFIG.SERVER_URL;
-  opts.headers = {
-    'cache-control': false,
-    'content-type': 'application/json',
-    'X-Parse-Application-Id': PARSE_CONFIG.APP_ID,
-    'X-Parse-Master-Key': PARSE_CONFIG.MASTER_KEY,
-    'X-Parse-REST-API-Key': PARSE_CONFIG.REST_KEY,
-    'X-Parse-Javascript-Key': PARSE_CONFIG.JAVASCRIPT_KEY,
-  };
-  opts.requests = requests;
-
+module.exports.run = (opts = {}, track = false) => new Promise((resolve, reject) => {
   const instance = autocannon(opts, (err, result) => {
     if (err) {
       reject(err);
@@ -22,10 +9,9 @@ module.exports.run = (opts = {}, requests = []) => new Promise((resolve, reject)
       resolve(result);
     }
   });
-  if (process.env.DEBUG) {
+  if (process.env.DEBUG || track) {
     autocannon.track(instance);
   }
-
   // this is used to kill the instance on CTRL-C
   process.once('SIGINT', () => {
     instance.stop();

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 
+const { run } = require('./autocannon');
 const program = require('commander');
 const inquirer = require('inquirer');
 const bench = require('./bench');
@@ -27,6 +28,15 @@ program
   .action(function (options) {
     handleAction(options);
   });
+
+program
+  .command('options <path to json>')
+  .action(async (path) => {
+    console.log(path);
+    const options = fs.readFileSync(path, 'utf8');
+    await run(JSON.parse(options), true);
+  });
+
 program.parse(process.argv);
 
 // No arguments


### PR DESCRIPTION
This tool is a wrapper for [autocannon](https://github.com/mcollina/autocannon#usage). 

Allow directly passing options for benchmarking.

Provides sample json file with parse server headers and requests.

```
npm start -- options ./options.sample.json -c 100 -p 1 -d 20
```